### PR TITLE
ListGroupRights proper localization

### DIFF
--- a/OreDict.php
+++ b/OreDict.php
@@ -52,6 +52,9 @@ $wgHooks['ParserFirstCallInit'][] = 'OreDictHooks::SetupParser';
 $wgHooks['EditPage::showEditForm:initial'][] = 'OreDictHooks::OutputWarnings';
 $wgHooks['LoadExtensionSchemaUpdates'][] = 'OreDictHooks::SchemaUpdate';
 
+$wgAvailableRights[] = 'edittilesheets';
+$wgAvailableRights[] = 'importtilesheets';
+
 // Resource loader modules
 $wgResourceModules['ext.oredict.list'] = array(
 	'styles' => 'css/ext.oredict.list.css',

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -54,5 +54,9 @@
 	"log-description-oredict": "Here you can find a list of changes made to OreDict entries.",
 	"logentry-oredict-editentry": "$1 edited entry #$15 ($7{{#if:$8|&nbsp;from $8}}). Changes: $4;",
 	"logentry-oredict-createentry": "$1 created entry #$4 ($6{{#if:$7|&nbsp;from $7}}) and assigned it to the $5 tag and set the bits $9.",
-	"logentry-oredict-edittag": "$1 toggled bits $5 on $4."
+	"logentry-oredict-edittag": "$1 toggled bits $5 on $4.",
+	"action-editoredict": "edit OreDict entries",
+	"right-editoredict": "Edit entries for the OreDict extension",
+	"action-importoredict": "mass-import OreDict entries",
+	"right-importoredict": "Mass-import entries for the OreDict extension"
 }


### PR DESCRIPTION
I added action-* and right-* entries to the base language JSON file. I read that this is how you do it on [a MediaWiki manual](https://www.mediawiki.org/wiki/Manual:User_rights#Adding_new_rights), but if that's outdated or not correct for this extension for some reason (I couldn't find $wgAvailableRights anywhere in the code, which makes me think we have to do it differently), then someone should definitely let me know.